### PR TITLE
Terraform Init Fix

### DIFF
--- a/app/graph/graph.py
+++ b/app/graph/graph.py
@@ -87,6 +87,7 @@ class StaticAnalyzerWorkflow:
         """
         try:
             result = self.graph.invoke({"file_path": context_files})
+            logging.info(result['static_analyzer_output'])
         except Exception as e:
             raise Exception(f"Terraform analysis failed: {e}")
 

--- a/app/graph/static_analyzer.py
+++ b/app/graph/static_analyzer.py
@@ -118,7 +118,7 @@ class StaticAnalyzer:
             # Check for the tofu files in the repo
             tofu_files = checkTofuFiles(output_folder)
             if tofu_files:
-                file_rename_map = convertFileExtension(output_folder, tofu_files)g
+                file_rename_map = convertFileExtension(output_folder, tofu_files)
             if not os.path.isfile(os.path.join(output_folder, ".terraform.lock.hcl")):
                 run(
                     ["terraform", "init", "-backend=false"],

--- a/app/graph/static_analyzer.py
+++ b/app/graph/static_analyzer.py
@@ -205,8 +205,6 @@ class StaticAnalyzer:
             static_analyzer_response = []
             static_analyzer_response = [f"{res.file_name}: {res.full_issue_description}" for res in
                                             response.issues]
-            if not static_analyzer_response:
-                static_analyzer_response = ["No issues found"]
 
         except Exception as e:
             log.error(

--- a/app/graph/static_analyzer.py
+++ b/app/graph/static_analyzer.py
@@ -147,13 +147,6 @@ class StaticAnalyzer:
                         capture_output=True,
                         text=True,
                     )
-                run(
-                    ["terraform", "init", "-backend=false"],
-                    check=True,
-                    cwd=output_folder,
-                    capture_output=True,
-                    text=True,
-                )
                 tflint_out = run(
                     ["tflint", "--format=compact", "--recursive"],
                     cwd=output_folder,

--- a/app/graph/static_analyzer.py
+++ b/app/graph/static_analyzer.py
@@ -202,9 +202,9 @@ class StaticAnalyzer:
                     f"{tf_lint_output}",
                 )}
             )
-            static_analyzer_response = []
             static_analyzer_response = [f"{res.file_name}: {res.full_issue_description}" for res in
-                                            response.issues]
+                                        response.issues]
+            log.info("The Static Analyzer output is", static_analyzer_response)
 
         except Exception as e:
             log.error(

--- a/app/graph/static_analyzer.py
+++ b/app/graph/static_analyzer.py
@@ -154,7 +154,13 @@ class StaticAnalyzer:
                     capture_output=True,
                     text=True,
                 )
-                tflint_out = run(["tflint", "--format=compact", "--recursive"],cwd=output_folder,stdout=PIPE,stderr=PIPE,text=True,)
+                tflint_out = run(
+                    ["tflint", "--format=compact", "--recursive"],
+                    cwd=output_folder,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    text=True,
+                )
                 lint_stdout = tflint_out.stdout
                 lint_stderr = tflint_out.stderr
         except CalledProcessError as e:


### PR DESCRIPTION
# Description
 While running in ACP mode or local mode we are sometimes getting "Run Terraform Init" command. 

#Current logic

1. We run "terraform init" only if the terraform validate is successful since it is a heavy command.
2. The issue is in ACP mode sometimes. the "terraform init" is not ran which is causing "terraform validate" to fail.

#Our fix

1. In our fix, we are checking whether the terraform empty file is present in the current working directory if it is present then there is no need to run "terraform init", instead run "tflint" directly.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/cisco-ai-agents/tf-code-analyzer-agntcy-agent/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
