### PR TITLE
fix for terraform init issue

### DIFF
--- a/app/graph/static_analyzer.py
+++ b/app/graph/static_analyzer.py
@@ -126,7 +126,6 @@ class StaticAnalyzer:
                 stderr=PIPE,
                 text=True,
             )
-            log.info("The terraform validate output", tf_validate_out.stderr)
             if tf_validate_out.returncode == 1 and "terraform init" in tf_validate_out.stderr:
                 # The directory expects terraform init to run so
                 run(
@@ -175,7 +174,7 @@ class StaticAnalyzer:
                 log.debug("Repo deleted successfully")
             except Exception as e:
                 log.error(
-                    f"An error occured while removing the local copy of the repo: {e}"
+                    f"An error occurred while removing the local copy of the repo: {e}"
                 )
                 return {}
 

--- a/app/graph/static_analyzer.py
+++ b/app/graph/static_analyzer.py
@@ -138,7 +138,6 @@ class StaticAnalyzer:
                     capture_output=True,
                     text=True,
                 )
-
                 tflint_out = run(
                     ["tflint", "--format=compact", "--recursive"],
                     cwd=output_folder,
@@ -187,7 +186,6 @@ class StaticAnalyzer:
                     f"{tf_lint_output}",
                 )}
             )
-            static_analyzer_response = []
             static_analyzer_response = [f"{res.file_name}: {res.full_issue_description}" for res in
                                             response.issues]
         except Exception as e:

--- a/app/graph/static_analyzer.py
+++ b/app/graph/static_analyzer.py
@@ -182,7 +182,7 @@ class StaticAnalyzer:
                 tf_lint_output = tf_lint_stdout
                 tf_lint_error = tf_lint_stderr
             prompt_template = create_static_analyzer_chain(self.chain)
-            response = self._context.chain.invoke(
+            response = prompt_template.invoke(
                 {
                     "linter_outputs": wrap_prompt(
                         "terraform init output:",

--- a/app/graph/static_analyzer.py
+++ b/app/graph/static_analyzer.py
@@ -126,6 +126,23 @@ class StaticAnalyzer:
                 stderr=PIPE,
                 text=True,
             )
+            log.info("The terraform validate output", tf_validate_out.stderr)
+            if tf_validate_out.returncode == 1 and "terraform init" in tf_validate_out.stderr:
+                # The directory expects terraform init to run so
+                run(
+                    ["terraform", "init", "-backend=false"],
+                    check=True,
+                    cwd=output_folder,
+                    capture_output=True,
+                    text=True,
+                )
+            tf_validate_out = run(
+                ["terraform", "validate", "-no-color"],
+                cwd=output_folder,
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
             lint_stdout, lint_stderr = "", ""
             # If terraform validate passes, run tflint
             if tf_validate_out.returncode == 0:


### PR DESCRIPTION
# Description

While running in ACP mode or local mode we are sometimes getting "Run Terraform Init" command.

#Current logic

We run "terraform init" only if the terraform validate is successful since it is a heavy command.
The issue is in ACP mode sometimes. the "terraform init" is not ran which is causing "terraform validate" to fail.
#Our fix

run Terraform init before Terraform Validate
Capture terraform init output & error along with the other output and error
Pass the terraform init output and error to the static analyzer output

Confluence: https://cisco-eti.atlassian.net/wiki/spaces/alfred/pages/1353548117/Terraform+Init+Issue+Analysis


Testing PR:
824 - https://github.com/Anusha-1209/PR_Replay_Without_Refactored_Code/pull/53
826 - https://github.com/Anusha-1209/PR_Replay_Without_Refactored_Code/pull/52
## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/cisco-ai-agents/tf-code-analyzer-agntcy-agent/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
